### PR TITLE
feat: integrate AdMob banner advertisements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.osmdroid)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.play.services.ads)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/otomotuzplus/MainActivity.kt
+++ b/app/src/main/java/com/example/otomotuzplus/MainActivity.kt
@@ -43,6 +43,7 @@ import com.example.otomotuzplus.utils.NotificationHelper
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentChange
 import com.google.firebase.messaging.FirebaseMessaging
+import com.google.android.gms.ads.MobileAds
 
 class MainActivity : ComponentActivity() {
     private val requestPermissionLauncher = registerForActivityResult(
@@ -67,6 +68,8 @@ class MainActivity : ComponentActivity() {
 
         NotificationHelper.createNotificationChannel(this, strings)
         enableEdgeToEdge()
+
+        MobileAds.initialize(this) {}
 
         setContent {
             var themeMode by remember { mutableStateOf(prefManager.getThemeMode()) }

--- a/app/src/main/java/com/example/otomotuzplus/ui/components/AdmobBanner.kt
+++ b/app/src/main/java/com/example/otomotuzplus/ui/components/AdmobBanner.kt
@@ -1,0 +1,23 @@
+package com.example.otomotuzplus.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+
+@Composable
+fun AdmobBanner(modifier: Modifier = Modifier) {
+    AndroidView(
+        modifier = modifier.fillMaxWidth(),
+        factory = { context ->
+            AdView(context).apply {
+                setAdSize(AdSize.BANNER)
+                adUnitId = "ca-app-pub-3940256099942544/6300978111"
+                loadAd(AdRequest.Builder().build())
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/otomotuzplus/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/otomotuzplus/ui/screens/home/HomeScreen.kt
@@ -67,6 +67,7 @@ import com.example.otomotuzplus.ui.models.sampleListings
 import com.example.otomotuzplus.ui.theme.BrandGold
 import com.example.otomotuzplus.ui.theme.DarkSlate800
 import com.example.otomotuzplus.ui.theme.Slate400
+import com.example.otomotuzplus.ui.components.AdmobBanner
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -214,6 +215,10 @@ fun HomeScreen(
                         onCarClick(originalCarFromDb)
                     }
             )
+            if ((index + 1) % 3 == 0) {
+                Spacer(modifier = Modifier.height(14.dp))
+                AdmobBanner(modifier = Modifier.padding(horizontal = 16.dp))
+            }
         }
 
         item {

--- a/app/src/main/java/com/example/otomotuzplus/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/otomotuzplus/ui/screens/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import com.example.otomotuzplus.ui.components.SettingsClickItem
 import com.example.otomotuzplus.ui.models.AppStrings
 import com.example.otomotuzplus.utils.NotificationHelper
 import com.google.firebase.auth.FirebaseAuth
+import com.example.otomotuzplus.ui.components.AdmobBanner
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -166,6 +167,8 @@ fun SettingsScreen(
             )
 
             Spacer(modifier = Modifier.weight(1f))
+            AdmobBanner()
+            Spacer(modifier = Modifier.height(24.dp))
 
             Button(
                 onClick = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ constraintlayout = "2.1.4"
 firebaseMessaging = "24.0.0"
 firebaseFirestore = "25.1.1"
 osmdroid = "6.1.20"
+playServicesAds = "25.3.0"
 
 [libraries]
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
@@ -48,6 +49,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx", version.ref = "firebaseMessaging" }
 osmdroid = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid" }
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Add AdMob SDK dependency and configuration in `AndroidManifest.xml`
- Initialize `MobileAds` in `MainActivity`
- Create a reusable `AdmobBanner` component using `AndroidView`
- Integrate banner ads into `HomeScreen` car list (appearing every 3 items)
- Add a banner ad to the bottom of the `SettingsScreen`